### PR TITLE
Sletter blanke linjer mellom "metadata"-setningene i main.adoc 

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -1,8 +1,6 @@
 include::locale/attributes.adoc[]
-
 = Spesifikasjon for beskrivelse av formål og hjemmel
 Versjon 1.0
-
 :description: Spesifikasjon for beskrivelse av formål og hjemmel
 :doctype: book
 :icons: font


### PR DESCRIPTION
... for at innholdsfortegnelsen og lyspæra foran nedlasting skal vises i lokal html (jf. Stig sin kommentar til forrige merge).